### PR TITLE
Fix centering of slideshow on pet page

### DIFF
--- a/portfolio/src/main/webapp/pet.html
+++ b/portfolio/src/main/webapp/pet.html
@@ -50,17 +50,18 @@
           <!-- Container for the image gallery -->
           <div class="container">
             <div class="slide">
-              <img src="images/dog1.jpg" alt="Luci" class="dog-image">
+              <img class="img-fluid" src="images/dog1.jpg" alt="Luci" class="dog-image">
             </div>
             <div class="slide">
-              <img src="images/dog2.jpg" alt="Luci with a flower" class="dog-image">
+              <img class="img-fluid" src="images/dog2.jpg" alt="Luci with a flower" class="dog-image">
             </div>
             <div class="slide">
-              <img src="images/dog3.jpg" alt="Luci as a puppy" class="dog-image">
+              <img class="img-fluid" src="images/dog3.jpg" alt="Luci as a puppy" class="dog-image">
             </div>
             <!-- Next and previous buttons -->
-            <a class="prev" onclick="nextSlide(-1)">&#10094;</a>
-            <a class="next" onclick="nextSlide(1)">&#10095;</a>
+            <a class="prev" onclick="nextSlide(-1)">&#10094;&#10094;</a>
+            <a class="next" onclick="nextSlide(1)">&#10095;&#10095;</a>
+            <br>
           </div>
         </div>
       </div>

--- a/portfolio/src/main/webapp/pnw.html
+++ b/portfolio/src/main/webapp/pnw.html
@@ -88,6 +88,7 @@
                   <a href="images/snow.jpg" class="d-block mb-4 h-100">
                   <img src="images/snow.jpg" alt="Top of Poo Poo Point">
                   </a>
+                  <br>
                 </div>
               </div>
             </div>

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -46,14 +46,14 @@ img {
 
 /* Position the "next button" to the right */
 .next {
-  right: 0;
+  right: 2%;
   border-radius: 3px 0 0 3px;
 }
 
 /* On hover, add a black background color with a little bit see-through */
 .prev:hover,
 .next:hover {
-  background-color: black;
+  background-color: white;
 }
 
 .active,


### PR DESCRIPTION
Previously, the next and previous buttons for the slideshow were off-center. This fix makes the right arrow better positioned. The hover color was also changed to white for better visibility.

Before:
![Screenshot 2020-06-24 at 8 29 22 AM](https://user-images.githubusercontent.com/36430384/85591773-6ccc4800-b5fa-11ea-8b0d-de07e760c9a1.png)
After:
![Screenshot 2020-06-24 at 9 09 11 AM](https://user-images.githubusercontent.com/36430384/85591767-6b9b1b00-b5fa-11ea-982a-d76e9e5e48ce.png)
