### PR TITLE
Redesign image grid to minimize white space

### DIFF
--- a/portfolio/src/main/webapp/pnw.html
+++ b/portfolio/src/main/webapp/pnw.html
@@ -79,7 +79,7 @@
                   </div>
                 </div>
                 <!--Modal: Name-->
-                <a><img class="img-fluid z-depth-1" src="images/poopoopoint.jpg" alt="Base of Poo Poo Point hike"
+                <a><img class="img-fluid z-depth-1 pnw-image" src="images/poopoopoint.jpg" alt="Base of Poo Poo Point hike"
                   data-toggle="modal" data-target="#modal1"></a>
                 <!--Modal: Name-->
                 <div class="modal fade" id="modal2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
@@ -101,7 +101,7 @@
                   </div>
                 </div>
                 <!--Modal: Name-->
-                <a><img class="img-fluid z-depth-1" src="images/vancouver.jpeg" alt="Vancouver, CA"
+                <a><img class="img-fluid z-depth-1 pnw-image" src="images/vancouver.jpeg" alt="Vancouver, CA"
                   data-toggle="modal" data-target="#modal2"></a>
               </div>
               <!-- Grid column -->
@@ -127,7 +127,7 @@
                   </div>
                 </div>
                 <!--Modal: Name-->
-                <a><img class="img-fluid z-depth-1" src="images/snoqualmie.jpg" alt="Snoqualmie Falls"
+                <a><img class="img-fluid z-depth-1 pnw-image" src="images/snoqualmie.jpg" alt="Snoqualmie Falls"
                   data-toggle="modal" data-target="#modal6"></a>
                 <!--Modal: Name-->
                 <div class="modal fade" id="modal5" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
@@ -149,7 +149,7 @@
                   </div>
                 </div>
                 <!--Modal: Name-->
-                <a><img class="img-fluid z-depth-1" src="images/columbia.jpg" alt="Columbia River in Eastern WA"
+                <a><img class="img-fluid z-depth-1 pnw-image" src="images/columbia.jpg" alt="Columbia River in Eastern WA"
                   data-toggle="modal" data-target="#modal5"></a>
               </div>
               <!-- Grid column -->
@@ -175,7 +175,7 @@
                   </div>
                 </div>
                 <!--Modal: Name-->
-                <a><img class="img-fluid z-depth-1" src="images/twinfalls.jpg" alt="Twin Falls"
+                <a><img class="img-fluid z-depth-1 pnw-image" src="images/twinfalls.jpg" alt="Twin Falls"
                   data-toggle="modal" data-target="#modal4"></a>
                 <!--Modal: Name-->
                 <div class="modal fade" id="modal3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
@@ -197,7 +197,7 @@
                   </div>
                 </div>
                 <!--Modal: Name-->
-                <a><img class="img-fluid z-depth-1" src="images/cherryblossoms.jpeg" alt="Cherry blossoms at UW"
+                <a><img class="img-fluid z-depth-1 pnw-image" src="images/cherryblossoms.jpeg" alt="Cherry blossoms at UW"
                   data-toggle="modal" data-target="#modal3"></a>
               </div>
               <!-- Grid column -->

--- a/portfolio/src/main/webapp/pnw.html
+++ b/portfolio/src/main/webapp/pnw.html
@@ -81,66 +81,6 @@
                 <!--Modal: Name-->
                 <a><img class="img-fluid z-depth-1" src="images/poopoopoint.jpg" alt="Base of Poo Poo Point hike"
                   data-toggle="modal" data-target="#modal1"></a>
-              </div>
-              <!-- Grid column -->
-              <!-- Grid column -->
-              <div class="col-lg-4 col-md-6 mb-4">
-                <!--Modal: Name-->
-                <div class="modal fade" id="modal6" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-                  <div class="modal-dialog modal-lg" role="document">
-                    <!--Content-->
-                    <div class="modal-content">
-                      <!--Body-->
-                      <div class="modal-body mb-0 p-0">
-                        <img class="embed-responsive-item" src="images/snoqualmie.jpg"></img>
-                      </div>
-                      <!--Footer-->
-                      <div class="modal-footer justify-content-center">
-                        <p><strong>Snoqualmie Falls, Snoqualmie</strong> - Snoqualmie Falls is a popular tourist
-                          destination. It's about a 10 minute drive from my home.
-                        </p>
-                      </div>
-                    </div>
-                    <!--/.Content-->
-                  </div>
-                </div>
-                <!--Modal: Name-->
-                <a><img class="img-fluid z-depth-1" src="images/snoqualmie.jpg" alt="Snoqualmie Falls"
-                  data-toggle="modal" data-target="#modal6"></a>
-              </div>
-              <!-- Grid column -->
-              <!-- Grid column -->
-              <div class="col-lg-4 col-md-6 mb-4">
-                <!--Modal: Name-->
-                <div class="modal fade" id="modal4" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-                  <div class="modal-dialog modal-lg" role="document">
-                    <!--Content-->
-                    <div class="modal-content">
-                      <!--Body-->
-                      <div class="modal-body mb-0 p-0">
-                        <img class="embed-responsive-item" src="images/twinfalls.jpg"></img>
-                      </div>
-                      <!--Footer-->
-                      <div class="modal-footer justify-content-center">
-                        <p><strong>Twin Falls, North Bend</strong> - Twin Falls is a relatively short hike with a nice
-                          view of waterfalls at the top. The trail mostly follows the river pictured here.
-                        </p>
-                      </div>
-                    </div>
-                    <!--/.Content-->
-                  </div>
-                </div>
-                <!--Modal: Name-->
-                <a><img class="img-fluid z-depth-1" src="images/twinfalls.jpg" alt="Twin Falls"
-                  data-toggle="modal" data-target="#modal4"></a>
-              </div>
-              <!-- Grid column -->
-            </div>
-            <!-- Grid row -->
-            <!-- Grid row -->
-            <div class="row">
-              <!-- Grid column -->
-              <div class="col-lg-4 col-md-12 mb-4">
                 <!--Modal: Name-->
                 <div class="modal fade" id="modal2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog modal-lg" role="document">
@@ -168,6 +108,28 @@
               <!-- Grid column -->
               <div class="col-lg-4 col-md-6 mb-4">
                 <!--Modal: Name-->
+                <div class="modal fade" id="modal6" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                  <div class="modal-dialog modal-lg" role="document">
+                    <!--Content-->
+                    <div class="modal-content">
+                      <!--Body-->
+                      <div class="modal-body mb-0 p-0">
+                        <img class="embed-responsive-item" src="images/snoqualmie.jpg"></img>
+                      </div>
+                      <!--Footer-->
+                      <div class="modal-footer justify-content-center">
+                        <p><strong>Snoqualmie Falls, Snoqualmie</strong> - Snoqualmie Falls is a popular tourist
+                          destination. It's about a 10 minute drive from my home.
+                        </p>
+                      </div>
+                    </div>
+                    <!--/.Content-->
+                  </div>
+                </div>
+                <!--Modal: Name-->
+                <a><img class="img-fluid z-depth-1" src="images/snoqualmie.jpg" alt="Snoqualmie Falls"
+                  data-toggle="modal" data-target="#modal6"></a>
+                <!--Modal: Name-->
                 <div class="modal fade" id="modal5" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog modal-lg" role="document">
                     <!--Content-->
@@ -193,6 +155,28 @@
               <!-- Grid column -->
               <!-- Grid column -->
               <div class="col-lg-4 col-md-6 mb-4">
+                <!--Modal: Name-->
+                <div class="modal fade" id="modal4" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                  <div class="modal-dialog modal-lg" role="document">
+                    <!--Content-->
+                    <div class="modal-content">
+                      <!--Body-->
+                      <div class="modal-body mb-0 p-0">
+                        <img class="embed-responsive-item" src="images/twinfalls.jpg"></img>
+                      </div>
+                      <!--Footer-->
+                      <div class="modal-footer justify-content-center">
+                        <p><strong>Twin Falls, North Bend</strong> - Twin Falls is a relatively short hike with a nice
+                          view of waterfalls at the top. The trail mostly follows the river pictured here.
+                        </p>
+                      </div>
+                    </div>
+                    <!--/.Content-->
+                  </div>
+                </div>
+                <!--Modal: Name-->
+                <a><img class="img-fluid z-depth-1" src="images/twinfalls.jpg" alt="Twin Falls"
+                  data-toggle="modal" data-target="#modal4"></a>
                 <!--Modal: Name-->
                 <div class="modal fade" id="modal3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                   <div class="modal-dialog modal-lg" role="document">

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -2,7 +2,6 @@ img {
     max-width: 100%;
     max-height: 100%;
     display: block;
-    padding: 8px
 }
 
 html, body {
@@ -31,6 +30,10 @@ html, body {
 .dog-image {
     width: 650px;
     height: 850px;
+}
+
+.pnw-image {
+    padding: 8px;
 }
 
 /* Hide the images by default */

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -2,6 +2,7 @@ img {
     max-width: 100%;
     max-height: 100%;
     display: block;
+    padding: 8px
 }
 
 html, body {


### PR DESCRIPTION
The grid was redesigned to get rid of extra white space from differently sized photos. An additional pnw-image class was made to specify padding between images.

Before:
![image](https://user-images.githubusercontent.com/36430384/85787259-f275f380-b6df-11ea-85c2-e09d8b47f678.png)

After:
![Screenshot 2020-06-25 at 12 21 01 PM - Display 2](https://user-images.githubusercontent.com/36430384/85787281-f99d0180-b6df-11ea-99b4-251501bea775.png)

