### PR TITLE
Make comments persist on page

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
@@ -25,16 +25,30 @@ import javax.servlet.http.HttpServletResponse;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
 
 /** Servlet that returns comments on index.html.*/
 @WebServlet("/comments")
 public class CommentsServlet extends HttpServlet {
 
-  private List<String> commentHistory = new ArrayList<>();
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Query query = new Query("Task");
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+    
+    List<String> commentHistory = new ArrayList<>();
+    for (Entity entity : results.asIterable()) {
+      String comment = (String) entity.getProperty("comment");
+
+      commentHistory.add(comment);
+    }
+
     response.setContentType("application/json");
     String json = new Gson().toJson(commentHistory);
     response.getWriter().println(json);
@@ -44,7 +58,6 @@ public class CommentsServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Get the input from the form.
     String newComment = request.getParameter("comment-input");
-    commentHistory.add(newComment);
 
     Entity taskEntity = new Entity("Task");
     taskEntity.setProperty("comment", newComment);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -57,7 +57,6 @@ function getCommentHistory() {
   fetch('/comments').then(response => response.json()).then((comments) => {
     // Build the list of history entries.
     const history = document.getElementById('history');
-    console.log("listing a comment...");
     comments.forEach((line) => {
       history.appendChild(createListElement(line));
     });

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -56,8 +56,8 @@ async function getMessages() {
 function getCommentHistory() {
   fetch('/comments').then(response => response.json()).then((comments) => {
     // Build the list of history entries.
-    console.log(comments);
     const history = document.getElementById('history');
+    console.log("listing a comment...");
     comments.forEach((line) => {
       history.appendChild(createListElement(line));
     });


### PR DESCRIPTION
The comments now persist on page on refresh and on closing and re-opening the server. 

A query was created to retrieve the Datastore. A loop was created to grab each entity, add it to an Arraylist, and display on the page.