### PR TITLE
Allow for uploaded images to be presented on page

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
@@ -65,11 +65,15 @@ public class CommentsServlet extends HttpServlet {
 
       String name = (String) entity.getProperty("name");
       String comment = (String) entity.getProperty("comment");
+      String image = (String) entity.getProperty("image");
+
+      String content = comment + " " + image;
 
       if (!commentHistory.containsKey(name)) {
           commentHistory.put(name, new ArrayList<>());
       }
-      commentHistory.get(name).add(comment);
+      
+      commentHistory.get(name).add(content);
       counter++;
     }
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -76,7 +76,7 @@ function refreshComments(num) {
     const history = document.getElementById('history');
     for (const [key, value] of Object.entries(comments)) {
       for (const comment of value) {
-        history.appendChild(createCommentElement([key, comment]));
+        history.appendChild(createCommentElement(key, comment));
       }
     }
   });
@@ -91,14 +91,21 @@ function deleteComments() {
 }
 
 /** Creates an <p> element containing text. */
-function createCommentElement(comment) {
+function createCommentElement(name, comment) {
   const divElement = document.createElement('div');
+  const nameElement = document.createElement('p');
   const pElement = document.createElement('p');
   const imgElement = document.createElement('img');
   const brElement = document.createElement('br');
 
-  pElement.innerText = comment.join('\n');
-  imgElement.setAttribute('src', 'https://i.kym-cdn.com/photos/images/newsfeed/000/954/161/b3a.jpg');
+  // separate the content string from text and image URL
+  const text = comment.substring(0, comment.lastIndexOf(" ") + 1);
+  const image = comment.substring(comment.lastIndexOf(" ") + 1, comment.length);
+
+  nameElement.innerText = name;
+  pElement.innerText = text;
+  imgElement.setAttribute('src', image);
+  divElement.appendChild(nameElement);
   divElement.appendChild(pElement);
   divElement.appendChild(imgElement);
   divElement.appendChild(brElement);


### PR DESCRIPTION
Instead of a hard-coded link, images uploaded by the user is now visible on the page.

The user can add text and.or image (demonstrated below). The text and image strings were concatenated and parsed in js.

![Screenshot 2020-07-07 at 12 51 35 PM - Display 2](https://user-images.githubusercontent.com/36430384/86835344-cf88ff00-c050-11ea-9a0f-382607d92699.png)
